### PR TITLE
Fix container build VCS stamping and permission issues

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -5,15 +5,15 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -o api-server ./cmd/api-server
-RUN CGO_ENABLED=0 GOOS=linux go build -o controller ./cmd/controller
+RUN CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -o /tmp/api-server ./cmd/api-server
+RUN CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -o /tmp/controller ./cmd/controller
 
 FROM registry.access.redhat.com/ubi9/ubi:latest
 
 WORKDIR /root/
 
-COPY --from=builder /app/api-server .
-COPY --from=builder /app/controller .
+COPY --from=builder /tmp/api-server .
+COPY --from=builder /tmp/controller .
 
 EXPOSE 8080
 


### PR DESCRIPTION
## Summary
- Fixed container build failure caused by Go VCS stamping feature
- Added `-buildvcs=false` flag to go build commands in Containerfile
- Resolved permission issues by building binaries to `/tmp/` directory
- Updated COPY commands to use new binary locations

## Problem
The container build was failing with two issues:
1. **VCS Stamping Error:**
   ```
   error obtaining VCS status: exit status 128
   Use -buildvcs=false to disable VCS stamping.
   ```

2. **Permission Error:**
   ```
   copying /tmp/go-build.../exe/a.out: open api-server: permission denied
   ```

## Root Cause Analysis
1. **VCS Stamping Issue:** Go 1.18+ includes a VCS stamping feature that tries to embed git repository information into binaries. In container builds, this fails due to git state inconsistencies when copying `.git` into container context.

2. **Permission Issue:** The UBI go-toolset container runs as non-root user (UID 1001), but the `/app` working directory doesn't have proper write permissions for creating binary files.

## Solution
1. **Disabled VCS stamping** with `-buildvcs=false` flag - eliminates VCS-related build errors
2. **Build to `/tmp/` directory** - resolves permission issues without requiring root user escalation
3. **Updated COPY commands** - copy binaries from new `/tmp/` location in multi-stage build

## Why This Approach is Better
- ✅ **Security:** Maintains least privilege principle (no root user escalation)
- ✅ **Best Practice:** Avoids running build processes as root
- ✅ **Portable:** Works consistently across different container environments  
- ✅ **Clean:** Separates build artifacts from source code location

## Testing
- [x] `make container-build` completes successfully
- [x] Container image builds without errors
- [x] All functionality preserved (VCS stamping is optional metadata)
- [x] Maintains security by avoiding root user usage

🤖 Generated with [Claude Code](https://claude.ai/code)