### PR TITLE
Fix API endpoints to match plan.md specification exactly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,10 @@ jobs:
       run: go mod verify
       
     - name: Run unit tests
-      run: go test -v -race -coverprofile=coverage.out ./test/unit/...
+      run: go test -v -race -coverprofile=coverage.out -timeout=5m ./test/unit/...
       
     - name: Run integration tests
-      run: go test -v -race ./test/integration/... || echo "No integration tests found"
+      run: go test -v -race -timeout=5m ./test/integration/... || echo "No integration tests found"
       
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -105,20 +105,22 @@ func (s *Server) setupRoutes() {
 			protected.GET("/session", s.getSessionHandler)        // GET /api/session - get current session
 
 			// Organization endpoints
-			protected.GET("/org", s.organizationsHandler)        // GET /api/org - list organizations
-			protected.GET("/org/:org-id", s.organizationHandler) // GET /api/org/{org-id} - get organization
+			protected.GET("/org", s.organizationsHandler)                        // GET /api/org - list organizations
+			protected.GET("/org/:org-id", s.organizationHandler)                 // GET /api/org/{org-id} - get organization
+			protected.GET("/org/:org-id/vdcs/query", s.vdcQueryHandler)          // GET /api/org/{org-id}/vdcs/query - list VDCs in organization
+			protected.GET("/org/:org-id/catalogs/query", s.catalogsQueryHandler) // GET /api/org/{org-id}/catalogs/query - list catalogs in organization
 
 			// VDC endpoints
 			protected.GET("/vdc/:vdc-id", s.vdcHandler)                                                     // GET /api/vdc/{vdc-id} - get VDC
+			protected.GET("/vdc/:vdc-id/vApps/query", s.vAppsQueryHandler)                                  // GET /api/vdc/{vdc-id}/vApps/query - list vApps in VDC
 			protected.POST("/vdc/:vdc-id/action/instantiateVAppTemplate", s.instantiateVAppTemplateHandler) // POST /api/vdc/{vdc-id}/action/instantiateVAppTemplate - instantiate vApp template
 
 			// Catalog endpoints
-			protected.GET("/catalogs/query", s.catalogsQueryHandler)                             // GET /api/catalogs/query - list catalogs
 			protected.GET("/catalog/:catalog-id", s.catalogHandler)                              // GET /api/catalog/{catalog-id} - get catalog
 			protected.GET("/catalog/:catalog-id/catalogItems/query", s.catalogItemsQueryHandler) // GET /api/catalog/{catalog-id}/catalogItems/query - list catalog items
+			protected.GET("/catalogItem/:item-id", s.catalogItemHandler)                         // GET /api/catalogItem/{item-id} - get catalog item
 
 			// vApp endpoints
-			protected.GET("/vApps/query", s.vAppsQueryHandler)      // GET /api/vApps/query - list vApps
 			protected.GET("/vApp/:vapp-id", s.vAppHandler)          // GET /api/vApp/{vapp-id} - get vApp
 			protected.DELETE("/vApp/:vapp-id", s.deleteVAppHandler) // DELETE /api/vApp/{vapp-id} - delete vApp
 

--- a/test/unit/api_test.go
+++ b/test/unit/api_test.go
@@ -843,8 +843,8 @@ func TestCatalogEndpoints(t *testing.T) {
 	token, err := jwtManager.Generate(user.ID, user.Username)
 	require.NoError(t, err)
 
-	t.Run("GET /api/catalogs/query returns catalog list", func(t *testing.T) {
-		req, _ := http.NewRequest("GET", "/api/catalogs/query", nil)
+	t.Run("GET /api/org/{org-id}/catalogs/query returns catalog list", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/api/org/"+org.ID.String()+"/catalogs/query", nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
@@ -972,7 +972,7 @@ func TestCatalogEndpoints(t *testing.T) {
 	})
 
 	t.Run("Catalog endpoints without token return 401", func(t *testing.T) {
-		req, _ := http.NewRequest("GET", "/api/catalogs/query", nil)
+		req, _ := http.NewRequest("GET", "/api/org/"+org.ID.String()+"/catalogs/query", nil)
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)
 


### PR DESCRIPTION
## Summary

Fixed API endpoints to ensure exact compliance with the plan.md specification and VMware Cloud Director API patterns.

## Changes Made

### 1. ✅ Added VDC Query Endpoint
- **New**: `GET /api/org/{org-id}/vdcs/query`
- Lists VDCs within a specific organization
- Includes proper organization access control
- Returns paginated VDC list with metadata

### 2. ✅ Fixed Catalog Query Endpoint  
- **Before**: `GET /api/catalogs/query` (global scope - wrong)
- **After**: `GET /api/org/{org-id}/catalogs/query` (organization-scoped - correct)
- Now properly follows hierarchical resource structure
- Enhanced access control for organization membership

### 3. ✅ Added Catalog Item Endpoint
- **New**: `GET /api/catalogItem/{item-id}`  
- Retrieves specific catalog item (vApp template) details
- Includes access control via catalog permissions
- Supports both shared and organization-specific catalogs

### 4. ✅ Fixed vApp Query Endpoint
- **Before**: `GET /api/vApps/query` (global scope - wrong)  
- **After**: `GET /api/vdc/{vdc-id}/vApps/query` (VDC-scoped - correct)
- Now properly follows VDC → vApp hierarchy
- Enhanced access control for VDC membership

## API Hierarchy Compliance

The endpoints now correctly follow the VMware Cloud Director hierarchical structure:

```
Organizations
├── VDCs (Virtual Data Centers)
│   └── vApps (Virtual Applications)
│       └── VMs (Virtual Machines)
└── Catalogs
    └── Catalog Items (vApp Templates)
```

## Endpoint Summary

**Organization Level:**
- `GET /api/org` - List organizations
- `GET /api/org/{org-id}` - Get organization details  
- `GET /api/org/{org-id}/vdcs/query` - List VDCs in organization ✨ **NEW**
- `GET /api/org/{org-id}/catalogs/query` - List catalogs in organization ✨ **FIXED**

**VDC Level:**  
- `GET /api/vdc/{vdc-id}` - Get VDC details
- `GET /api/vdc/{vdc-id}/vApps/query` - List vApps in VDC ✨ **FIXED**

**Catalog Level:**
- `GET /api/catalog/{catalog-id}` - Get catalog details
- `GET /api/catalogItem/{item-id}` - Get catalog item details ✨ **NEW**

**vApp/VM Level:**
- `GET /api/vApp/{vapp-id}` - Get vApp details
- `GET /api/vApp/{vapp-id}/vms/query` - List VMs in vApp
- `POST /api/vApp/{vapp-id}/vms` - Create VM in vApp
- `GET /api/vm/{vm-id}` - Get VM details
- `PUT /api/vm/{vm-id}` - Update VM  
- `DELETE /api/vm/{vm-id}` - Delete VM

## Testing

- All existing VM endpoint tests continue to pass ✅
- New endpoints include proper authentication and authorization
- Access control validates organization/VDC membership
- Error handling for invalid IDs and permissions

## Breaking Changes

⚠️ **API clients will need to update these endpoints:**

1. **Catalog queries**: Update from `/api/catalogs/query` to `/api/org/{org-id}/catalogs/query`
2. **vApp queries**: Update from `/api/vApps/query` to `/api/vdc/{vdc-id}/vApps/query`

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added endpoints to list Virtual Data Centers (VDCs) and catalogs within a specified organization, with access control based on user membership.
  * Introduced an endpoint to retrieve details of a specific catalog item by its ID.
  * Added endpoint to list vApps within a specific Virtual Data Center (VDC).

* **Improvements**
  * Catalog and vApp listing endpoints now require organization or VDC IDs, ensuring results are scoped to the specified resource and access is validated.
  * Enhanced error handling and consistent access checks across endpoints.

* **Chores**
  * Updated CI workflow to add a 5-minute timeout for unit and integration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->