### PR TITLE
Add VM power operations endpoints

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -130,6 +130,12 @@ func (s *Server) setupRoutes() {
 			protected.GET("/vm/:vm-id", s.vmHandler)                         // GET /api/vm/{vm-id} - get VM
 			protected.PUT("/vm/:vm-id", s.updateVMHandler)                   // PUT /api/vm/{vm-id} - update VM
 			protected.DELETE("/vm/:vm-id", s.deleteVMHandler)                // DELETE /api/vm/{vm-id} - delete VM
+
+			// VM power operation endpoints
+			protected.POST("/vm/:vm-id/power/action/powerOn", s.powerOnVMHandler)  // POST /api/vm/{vm-id}/power/action/powerOn - power on VM
+			protected.POST("/vm/:vm-id/power/action/powerOff", s.powerOffVMHandler) // POST /api/vm/{vm-id}/power/action/powerOff - power off VM
+			protected.POST("/vm/:vm-id/power/action/suspend", s.suspendVMHandler)   // POST /api/vm/{vm-id}/power/action/suspend - suspend VM
+			protected.POST("/vm/:vm-id/power/action/reset", s.resetVMHandler)       // POST /api/vm/{vm-id}/power/action/reset - reset VM
 		}
 	}
 }


### PR DESCRIPTION
## Summary
Implements the four VM power operation endpoints required by VMware Cloud Director API specification:

- `POST /api/vm/{vm-id}/power/action/powerOn` - Power on VM
- `POST /api/vm/{vm-id}/power/action/powerOff` - Power off VM  
- `POST /api/vm/{vm-id}/power/action/suspend` - Suspend VM
- `POST /api/vm/{vm-id}/power/action/reset` - Reset VM

## Features
- **Power State Validation**: Comprehensive validation logic prevents invalid state transitions with proper 409 Conflict responses
- **Authentication & Authorization**: Full JWT token validation and organization-based access control
- **VMware Cloud Director Compatible Responses**: Task-based response format with proper task IDs and status tracking
- **Database Integration**: VM status updates are persisted to PostgreSQL database
- **Comprehensive Error Handling**: Proper HTTP status codes (400, 401, 403, 404, 409, 500)

## Test Coverage
- ✅ 10 comprehensive test scenarios covering all four power operations
- ✅ Error cases: invalid VM IDs, non-existent VMs, unauthorized access
- ✅ Power state validation: prevents invalid transitions with proper error messages
- ✅ Database verification: confirms VM status updates are persisted correctly

## Test plan
- [x] All unit tests pass (`go test ./test/unit/...`)
- [x] Power operations work correctly for all four actions
- [x] Power state validation prevents invalid transitions
- [x] Authentication and authorization work correctly
- [x] Database updates are persisted
- [x] Error cases return proper HTTP status codes and messages

🤖 Generated with [Claude Code](https://claude.ai/code)