### PR TITLE
Fix template instantiation bugs and enhance RBAC permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ temp/
 # Meta
 .todo
 .issues
+pod.log

--- a/chart/ssvirt/templates/rbac.yaml
+++ b/chart/ssvirt/templates/rbac.yaml
@@ -70,6 +70,10 @@ rules:
 - apiGroups: ["template.openshift.io"]
   resources: ["templateinstances"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+# Template configurations for VM creation
+- apiGroups: ["template.openshift.io"]
+  resources: ["templateconfigs"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/api/handlers/validation.go
+++ b/pkg/api/handlers/validation.go
@@ -20,4 +20,9 @@ var (
 	// - Must start and end with alphanumeric characters
 	// - Must be 1-63 characters long
 	dns1123LabelRegex = regexp.MustCompile(`^[a-z0-9]([a-z0-9\-]{0,61}[a-z0-9])?$`)
+
+	// catalogItemURNRegex validates catalog item URN suffix format.
+	// Allows alphanumeric characters, hyphens, underscores, and colons.
+	// Supports both legacy 4-part format (item-name) and 5-part format (catalog-id:item-name)
+	catalogItemURNRegex = regexp.MustCompile(`^[a-zA-Z0-9\-_:]+$`)
 )

--- a/pkg/api/handlers/vm_creation.go
+++ b/pkg/api/handlers/vm_creation.go
@@ -367,6 +367,9 @@ func (h *VMCreationHandlers) InstantiateTemplate(c *gin.Context) {
 		// Get VDC to determine namespace
 		vdc, err := h.vdcRepo.GetByIDString(c.Request.Context(), vdcID)
 		if err != nil {
+			// Log detailed error for debugging but don't expose to client
+			fmt.Printf("Error retrieving VDC details for ID %s: %v\n", vdcID, err)
+
 			// Cleanup vApp and return error
 			if cleanupErr := h.vappRepo.DeleteWithValidation(c.Request.Context(), vapp.ID, true); cleanupErr != nil {
 				// Log cleanup error but don't fail the request
@@ -376,7 +379,6 @@ func (h *VMCreationHandlers) InstantiateTemplate(c *gin.Context) {
 				http.StatusInternalServerError,
 				"Internal Server Error",
 				"Failed to retrieve VDC details",
-				err.Error(),
 			))
 			return
 		}


### PR DESCRIPTION
## Summary
- Fixed foreign key constraint violation in template instantiation by setting VApp.TemplateID to nil for catalog items (virtual entities)
- Enhanced error handling to return proper HTTP status codes (400 for validation errors, 404 for not found, 500 for server errors)
- Added System Administrator bypass for catalog access restrictions to allow full access
- Fixed 4-part URN support by skipping catalog validation when catalog information is unavailable
- Fixed namespace resolution by using VDC's actual namespace field instead of generated names
- Added missing RBAC permissions for templateconfigs.template.openshift.io resource creation
- Updated unit tests to match new description format and behavior patterns
- Added comprehensive URN validation with proper error categorization

## Test plan
- [x] Run unit tests with `make test` - all tests pass
- [x] Run linting with `make lint` - no errors
- [x] Verify template instantiation works with both 4-part and 5-part URN formats
- [x] Confirm System Administrator access to all catalogs
- [x] Test proper error responses for invalid URNs (400) vs not found items (404)
- [x] Verify TemplateInstance creation succeeds with proper RBAC permissions

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support OpenShift TemplateConfigs via expanded permissions.
  * Enable Kubernetes-based template instantiation; vApp descriptions now include CatalogItem/TemplateInstance details with backward-compatible Template ID handling.
  * Support extended catalog item URN format (catalog-id:item-name).
  * System Administrators gain universal catalog access.

* **Bug Fixes**
  * Stricter catalog item URN validation with clearer errors.
  * Improved cleanup on failures and validation of missing namespaces.

* **Chores**
  * Ignore pod.log files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->