### PR TITLE
Add database connection retry logic for startup resilience

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -23,10 +23,13 @@ func main() {
 		log.Fatalf("Failed to load configuration: %v", err)
 	}
 
-	// Initialize database connection
-	db, err := database.NewConnection(cfg)
+	// Initialize database connection with retry logic
+	ctx := context.Background()
+	retryConfig := database.RetryConfigFromConfig(cfg)
+	log.Printf("Initializing database connection with retry logic (max attempts: %d)...", retryConfig.MaxAttempts)
+	db, err := database.NewConnectionWithRetry(ctx, cfg, retryConfig)
 	if err != nil {
-		log.Fatalf("Failed to connect to database: %v", err)
+		log.Fatalf("Failed to connect to database after retries: %v", err)
 	}
 
 	// Run database migrations

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,6 +24,12 @@ type Config struct {
 		MaxIdleConns    int           `mapstructure:"max_idle_connections"`
 		ConnMaxLifetime time.Duration `mapstructure:"conn_max_lifetime"`
 		ConnMaxIdleTime time.Duration `mapstructure:"conn_max_idle_time"`
+		Retry           struct {
+			MaxAttempts     int           `mapstructure:"max_attempts"`
+			InitialDelay    time.Duration `mapstructure:"initial_delay"`
+			MaxDelay        time.Duration `mapstructure:"max_delay"`
+			BackoffMultiple float64       `mapstructure:"backoff_multiple"`
+		} `mapstructure:"retry"`
 	} `mapstructure:"database"`
 
 	API struct {
@@ -76,6 +82,10 @@ func Load() (*Config, error) {
 	viper.SetDefault("database.max_idle_connections", 10)
 	viper.SetDefault("database.conn_max_lifetime", "1h")
 	viper.SetDefault("database.conn_max_idle_time", "10m")
+	viper.SetDefault("database.retry.max_attempts", 30)
+	viper.SetDefault("database.retry.initial_delay", "2s")
+	viper.SetDefault("database.retry.max_delay", "30s")
+	viper.SetDefault("database.retry.backoff_multiple", 1.5)
 	viper.SetDefault("api.port", 8080)
 	// JWT secret MUST be explicitly configured - no insecure default
 	if os.Getenv("SSVIRT_AUTH_JWT_SECRET") == "" {

--- a/pkg/database/retry.go
+++ b/pkg/database/retry.go
@@ -1,0 +1,92 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/mhrivnak/ssvirt/pkg/config"
+)
+
+// RetryConfig contains configuration for database connection retries
+type RetryConfig struct {
+	MaxAttempts     int
+	InitialDelay    time.Duration
+	MaxDelay        time.Duration
+	BackoffMultiple float64
+}
+
+// DefaultRetryConfig returns sensible defaults for database connection retries
+func DefaultRetryConfig() RetryConfig {
+	return RetryConfig{
+		MaxAttempts:     30,               // Try for up to 30 attempts
+		InitialDelay:    2 * time.Second,  // Start with 2 second delays
+		MaxDelay:        30 * time.Second, // Cap delays at 30 seconds
+		BackoffMultiple: 1.5,              // Increase delay by 50% each time
+	}
+}
+
+// RetryConfigFromConfig creates a RetryConfig from the application configuration
+func RetryConfigFromConfig(cfg *config.Config) RetryConfig {
+	return RetryConfig{
+		MaxAttempts:     cfg.Database.Retry.MaxAttempts,
+		InitialDelay:    cfg.Database.Retry.InitialDelay,
+		MaxDelay:        cfg.Database.Retry.MaxDelay,
+		BackoffMultiple: cfg.Database.Retry.BackoffMultiple,
+	}
+}
+
+// NewConnectionWithRetry attempts to connect to the database with exponential backoff retry logic
+// This function will block until either a successful connection is established or the context is cancelled
+func NewConnectionWithRetry(ctx context.Context, cfg *config.Config, retryConfig RetryConfig) (*DB, error) {
+	var lastErr error
+	delay := retryConfig.InitialDelay
+
+	log.Printf("Attempting to connect to database with retry logic (max attempts: %d)", retryConfig.MaxAttempts)
+
+	for attempt := 1; attempt <= retryConfig.MaxAttempts; attempt++ {
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("database connection cancelled: %w", ctx.Err())
+		default:
+		}
+
+		log.Printf("Database connection attempt %d/%d", attempt, retryConfig.MaxAttempts)
+
+		db, err := NewConnection(cfg)
+		if err == nil {
+			log.Printf("Database connection established successfully on attempt %d", attempt)
+			return db, nil
+		}
+
+		lastErr = err
+		log.Printf("Database connection attempt %d failed: %v", attempt, err)
+
+		// Don't wait after the final attempt
+		if attempt == retryConfig.MaxAttempts {
+			break
+		}
+
+		log.Printf("Waiting %v before next database connection attempt...", delay)
+
+		// Use a timer so we can respect context cancellation during the delay
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, fmt.Errorf("database connection cancelled during retry delay: %w", ctx.Err())
+		case <-timer.C:
+			// Continue to next attempt
+		}
+
+		// Calculate next delay with exponential backoff
+		delay = time.Duration(float64(delay) * retryConfig.BackoffMultiple)
+		if delay > retryConfig.MaxDelay {
+			delay = retryConfig.MaxDelay
+		}
+	}
+
+	return nil, fmt.Errorf("failed to connect to database after %d attempts, last error: %w",
+		retryConfig.MaxAttempts, lastErr)
+}


### PR DESCRIPTION
## Summary
Implement exponential backoff retry logic for both api-server and vm-controller to gracefully handle PostgreSQL startup delays in containerized environments.

## Changes Made

### New Database Retry System
- **Retry Logic**: Created `pkg/database/retry.go` with configurable exponential backoff mechanism
- **Configuration Support**: Added `database.retry` configuration section with tunable parameters
- **Context Awareness**: Retry logic respects context cancellation for graceful shutdown during startup

### Updated Components
- **API Server**: Replace direct `database.NewConnection()` with retry wrapper in `cmd/api-server/main.go`
- **VM Controller**: Replace direct `database.NewConnection()` with retry wrapper in `cmd/vm-controller/main.go`
- **Configuration**: Extended `pkg/config/config.go` with retry parameters and sensible defaults

### Configuration Parameters
All parameters can be configured via config file or environment variables (`SSVIRT_DATABASE_RETRY_*`):

- `database.retry.max_attempts`: Maximum connection attempts (default: 30)
- `database.retry.initial_delay`: Starting delay between attempts (default: 2s)  
- `database.retry.max_delay`: Maximum delay cap (default: 30s)
- `database.retry.backoff_multiple`: Exponential backoff multiplier (default: 1.5)

### Key Benefits
- **🚀 Startup Resilience**: Services patiently wait for PostgreSQL instead of failing immediately
- **⚙️ Configurable Behavior**: Retry behavior can be fine-tuned for different environments
- **🛡️ Production Ready**: Exponential backoff prevents overwhelming the database with connection attempts
- **📊 Observable**: Detailed logging helps with troubleshooting startup issues
- **🔄 Graceful Degradation**: Services can be cancelled cleanly during startup without hanging

## Test Plan
- [x] All existing tests pass
- [x] Linter passes without issues
- [x] Code compiles successfully for both components
- [x] Retry logic includes proper error handling and context cancellation
- [x] Configuration defaults are sensible for production use

## Technical Details

The retry implementation uses:
- **Exponential backoff** with configurable multiplier to avoid overwhelming the database
- **Context cancellation** support for clean shutdown during startup
- **Timer-based delays** that respect cancellation instead of blocking sleeps
- **Comprehensive logging** for each attempt to aid in troubleshooting

This addresses the common issue in containerized environments where services start in unpredictable order, ensuring robust startup behavior when PostgreSQL takes time to become ready.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Startup now automatically retries database connections with exponential backoff, improving reliability during transient outages.
  - Added configurable retry settings (max attempts, initial delay, max delay, backoff multiple) via app configuration, with sensible defaults.
  - Enhanced startup logs to surface retry policy and attempt status, including clearer failure messaging if all retries are exhausted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->