### PR TITLE
Fix VApp deletion SQL column error

### DIFF
--- a/pkg/database/models/vm.go
+++ b/pkg/database/models/vm.go
@@ -10,7 +10,7 @@ type VM struct {
 	ID          string         `gorm:"type:varchar(255);primary_key" json:"id"`
 	Name        string         `gorm:"not null" json:"name"`
 	Description string         `json:"description"`
-	VAppID      string         `gorm:"type:varchar(255);not null;index" json:"vapp_id"`
+	VAppID      string         `gorm:"column:vapp_id;type:varchar(255);not null;index" json:"vapp_id"`
 	VMName      string         `json:"vm_name"`   // OpenShift VM resource name
 	Namespace   string         `json:"namespace"` // OpenShift namespace
 	Status      string         `json:"status"`

--- a/pkg/database/repositories/vm.go
+++ b/pkg/database/repositories/vm.go
@@ -75,7 +75,7 @@ func (r *VMRepository) GetByOrganizationIDs(orgIDs []string) ([]models.VM, error
 
 	var vms []models.VM
 	err := r.db.Preload("VApp").Preload("VApp.VDC").Preload("VApp.VDC.Organization").
-		Joins("JOIN v_apps ON vms.v_app_id = v_apps.id").
+		Joins("JOIN v_apps ON vms.vapp_id = v_apps.id").
 		Joins("JOIN vdcs ON v_apps.vdc_id = vdcs.id").
 		Where("vdcs.organization_id IN ?", orgIDs).
 		Find(&vms).Error
@@ -89,13 +89,13 @@ func (r *VMRepository) GetByOrganizationIDsWithFilters(orgIDs []string, vappID *
 
 	// Build the base query
 	query := r.db.Preload("VApp").Preload("VApp.VDC").Preload("VApp.VDC.Organization").
-		Joins("JOIN v_apps ON vms.v_app_id = v_apps.id").
+		Joins("JOIN v_apps ON vms.vapp_id = v_apps.id").
 		Joins("JOIN vdcs ON v_apps.vdc_id = vdcs.id").
 		Where("vdcs.organization_id IN ?", orgIDs)
 
 	// Apply filters
 	if vappID != nil {
-		query = query.Where("vms.v_app_id = ?", *vappID)
+		query = query.Where("vms.vapp_id = ?", *vappID)
 	}
 	if status != "" {
 		query = query.Where("vms.status = ?", status)
@@ -104,12 +104,12 @@ func (r *VMRepository) GetByOrganizationIDsWithFilters(orgIDs []string, vappID *
 	// Count total records
 	var total int64
 	countQuery := r.db.Table("vms").
-		Joins("JOIN v_apps ON vms.v_app_id = v_apps.id").
+		Joins("JOIN v_apps ON vms.vapp_id = v_apps.id").
 		Joins("JOIN vdcs ON v_apps.vdc_id = vdcs.id").
 		Where("vdcs.organization_id IN ?", orgIDs)
 
 	if vappID != nil {
-		countQuery = countQuery.Where("vms.v_app_id = ?", *vappID)
+		countQuery = countQuery.Where("vms.vapp_id = ?", *vappID)
 	}
 	if status != "" {
 		countQuery = countQuery.Where("vms.status = ?", status)
@@ -135,7 +135,7 @@ func (r *VMRepository) GetByOrganizationIDsWithFilters(orgIDs []string, vappID *
 func (r *VMRepository) GetByVAppIDWithFilters(vappID string, status string, limit, offset int) ([]models.VM, int64, error) {
 	// Build the base query for specific vApp
 	query := r.db.Preload("VApp").Preload("VApp.VDC").Preload("VApp.VDC.Organization").
-		Where("v_app_id = ?", vappID)
+		Where("vapp_id = ?", vappID)
 
 	// Apply status filter
 	if status != "" {
@@ -144,7 +144,7 @@ func (r *VMRepository) GetByVAppIDWithFilters(vappID string, status string, limi
 
 	// Count total records
 	var total int64
-	countQuery := r.db.Table("vms").Where("v_app_id = ?", vappID)
+	countQuery := r.db.Table("vms").Where("vapp_id = ?", vappID)
 	if status != "" {
 		countQuery = countQuery.Where("status = ?", status)
 	}
@@ -200,7 +200,7 @@ func (r *VMRepository) GetByNamespaceAndVMName(ctx context.Context, namespace, v
 func (r *VMRepository) GetByVAppAndVMName(ctx context.Context, vappID, vmName string) (*models.VM, error) {
 	var vm models.VM
 	err := r.db.WithContext(ctx).
-		Where("v_app_id = ? AND vm_name = ?", vappID, vmName).
+		Where("vapp_id = ? AND vm_name = ?", vappID, vmName).
 		First(&vm).Error
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- Fixes SQL error "column 'vapp_id' does not exist" during VApp deletion
- Adds explicit GORM column mapping to VM model 
- Updates all queries to use consistent `vapp_id` column name

## Test plan
- [x] Run VM repository tests - all passing
- [x] Run go vet and golangci-lint - no issues
- [x] Verify column name consistency across all VM queries

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected VM-to-vApp linkage in database queries to ensure accurate results.
  - Fixed issues causing missing or incorrect VMs when filtering by organization, vApp, or VM name.
  - Improved consistency between filtered lists and their counts in paginated views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->