### PR TITLE
Fix vApp description auto-generation issue

### DIFF
--- a/test/unit/vm_creation_api_test.go
+++ b/test/unit/vm_creation_api_test.go
@@ -94,10 +94,10 @@ func TestVMCreationAPIEndpoints(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, "test-vapp", response.Name)
-			assert.Equal(t, "Test vApp from template\nCatalogItem: urn:vcloud:catalogitem:template-123", response.Description)
+			assert.Equal(t, "Test vApp from template", response.Description)
 			assert.Equal(t, "RESOLVED", response.Status)
 			assert.Equal(t, vdc.ID, response.VDCID)
-			assert.Equal(t, "urn:vcloud:catalogitem:template-123", response.TemplateID)
+			assert.Equal(t, "", response.TemplateID) // No longer auto-generated from description
 			assert.Contains(t, response.ID, "urn:vcloud:vapp:")
 			assert.Contains(t, response.Href, "/cloudapi/1.0.0/vapps/")
 		})
@@ -375,10 +375,10 @@ func TestVMCreationAPIEndpoints(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, "sysadmin-test-vapp", response.Name)
-			assert.Equal(t, "Test vApp from template by System Admin\nCatalogItem: urn:vcloud:catalogitem:admin-template-123", response.Description)
+			assert.Equal(t, "Test vApp from template by System Admin", response.Description)
 			assert.Equal(t, "RESOLVED", response.Status)
 			assert.Equal(t, vdc.ID, response.VDCID)
-			assert.Equal(t, "urn:vcloud:catalogitem:admin-template-123", response.TemplateID)
+			assert.Equal(t, "", response.TemplateID) // No longer auto-generated from description
 			assert.Contains(t, response.ID, "urn:vcloud:vapp:")
 			assert.Contains(t, response.Href, "/cloudapi/1.0.0/vapps/")
 		})


### PR DESCRIPTION
## Summary
- Fixes unwanted auto-generation of CatalogItem and TemplateInstance URNs in vApp description field
- Removes automatic addition of "CatalogItem: <urn>" and "TemplateInstance: <name>" text 
- vApp description now remains clean and contains only user-provided content
- Updates tests to reflect new behavior

## Test plan
- [x] VM creation tests passing with clean descriptions
- [x] All handler tests passing
- [x] go vet and golangci-lint clean

Fixes https://github.com/mhrivnak/ssvirt/issues/53

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - VM creation response now preserves the exact Description provided, without appending catalog item details.
  - TemplateID in the VM creation response is no longer auto-derived from catalog items and will be empty unless explicitly set.
  - No changes to other response fields.

- Tests
  - Updated unit tests to reflect the new VM creation response shape (clean Description and empty TemplateID in success cases).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->