### PR TITLE
Fix vApp deletion to cleanup associated TemplateInstance resources

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -95,7 +95,7 @@ func NewServer(cfg *config.Config, db *database.DB, authSvc *auth.Service, jwtMa
 		catalogItemHandlers: handlers.NewCatalogItemHandler(catalogItemRepo),
 		sessionHandlers:     handlers.NewSessionHandlers(userRepo, authSvc, jwtManager, cfg),
 		vmCreationHandlers:  handlers.NewVMCreationHandlers(vdcRepo, vappRepo, catalogItemRepo, catalogRepo, k8sService),
-		vappHandlers:        handlers.NewVAppHandlers(vappRepo, vdcRepo, vmRepo),
+		vappHandlers:        handlers.NewVAppHandlers(vappRepo, vdcRepo, vmRepo, k8sService),
 		vmHandlers:          handlers.NewVMHandlers(vmRepo, vappRepo, vdcRepo),
 		powerMgmtHandlers:   createPowerManagementHandler(vmRepo, k8sService),
 	}

--- a/test/unit/vapp_deletion_test.go
+++ b/test/unit/vapp_deletion_test.go
@@ -1,0 +1,296 @@
+package unit
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/mhrivnak/ssvirt/pkg/api/handlers"
+	"github.com/mhrivnak/ssvirt/pkg/auth"
+	"github.com/mhrivnak/ssvirt/pkg/database/models"
+	"github.com/mhrivnak/ssvirt/pkg/database/repositories"
+	"github.com/mhrivnak/ssvirt/pkg/services"
+)
+
+// MockKubernetesService is a mock implementation of KubernetesService
+type MockKubernetesService struct {
+	mock.Mock
+}
+
+func (m *MockKubernetesService) Start(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *MockKubernetesService) Stop(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *MockKubernetesService) HealthCheck(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *MockKubernetesService) CreateNamespaceForVDC(ctx context.Context, vdc *models.VDC, org *models.Organization) error {
+	args := m.Called(ctx, vdc, org)
+	return args.Error(0)
+}
+
+func (m *MockKubernetesService) UpdateNamespaceForVDC(ctx context.Context, vdc *models.VDC, org *models.Organization) error {
+	args := m.Called(ctx, vdc, org)
+	return args.Error(0)
+}
+
+func (m *MockKubernetesService) DeleteNamespaceForVDC(ctx context.Context, vdc *models.VDC) error {
+	args := m.Called(ctx, vdc)
+	return args.Error(0)
+}
+
+func (m *MockKubernetesService) EnsureNamespaceForVDC(ctx context.Context, vdc *models.VDC, org *models.Organization) error {
+	args := m.Called(ctx, vdc, org)
+	return args.Error(0)
+}
+
+func (m *MockKubernetesService) GetTemplate(ctx context.Context, name string) (*services.TemplateInfo, error) {
+	args := m.Called(ctx, name)
+	if template := args.Get(0); template != nil {
+		return template.(*services.TemplateInfo), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *MockKubernetesService) CreateTemplateInstance(ctx context.Context, req *services.TemplateInstanceRequest) (*services.TemplateInstanceResult, error) {
+	args := m.Called(ctx, req)
+	if result := args.Get(0); result != nil {
+		return result.(*services.TemplateInstanceResult), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *MockKubernetesService) GetTemplateInstance(ctx context.Context, namespace, name string) (*services.TemplateInstanceStatus, error) {
+	args := m.Called(ctx, namespace, name)
+	if status := args.Get(0); status != nil {
+		return status.(*services.TemplateInstanceStatus), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *MockKubernetesService) DeleteTemplateInstance(ctx context.Context, namespace, name string) error {
+	args := m.Called(ctx, namespace, name)
+	return args.Error(0)
+}
+
+func (m *MockKubernetesService) EnsureNamespaceResources(ctx context.Context, namespace string, vdc *models.VDC) error {
+	args := m.Called(ctx, namespace, vdc)
+	return args.Error(0)
+}
+
+func (m *MockKubernetesService) GetClient() client.Client {
+	args := m.Called()
+	if clientVal := args.Get(0); clientVal != nil {
+		return clientVal.(client.Client)
+	}
+	return nil
+}
+
+func TestVAppDeletion_CleansUpTemplateInstance(t *testing.T) {
+	// Setup test infrastructure
+	_, db, jwtManager := setupTestAPIServer(t)
+
+	// Create mock Kubernetes service
+	mockK8sService := &MockKubernetesService{}
+
+	// Setup repositories
+	orgRepo := repositories.NewOrganizationRepository(db.DB)
+	vdcRepo := repositories.NewVDCRepository(db.DB)
+	vappRepo := repositories.NewVAppRepository(db.DB)
+	vmRepo := repositories.NewVMRepository(db.DB)
+
+	// Create VApp handlers with mock K8s service
+	vappHandlers := handlers.NewVAppHandlers(vappRepo, vdcRepo, vmRepo, mockK8sService)
+
+	// Create test data
+	// 1. Create organization
+	org := &models.Organization{
+		Name:        "TestOrg",
+		DisplayName: "Test Organization",
+		IsEnabled:   true,
+	}
+	require.NoError(t, orgRepo.Create(org))
+
+	// 2. Create VDC
+	vdc := &models.VDC{
+		Name:            "TestVDC",
+		Description:     "Test VDC for vApp deletion",
+		OrganizationID:  org.ID,
+		AllocationModel: models.PayAsYouGo,
+		Namespace:       "test-namespace",
+		IsEnabled:       true,
+	}
+	require.NoError(t, vdcRepo.Create(vdc))
+
+	// 3. Create vApp
+	vapp := &models.VApp{
+		Name:        "test-vapp",
+		Description: "Test vApp for deletion",
+		VDCID:       vdc.ID,
+		Status:      models.VAppStatusDeployed,
+	}
+	require.NoError(t, vappRepo.CreateWithContext(context.Background(), vapp))
+
+	// 4. Create user
+	user := &models.User{
+		Username: "testuser",
+		Email:    "test@example.com",
+		FullName: "Test User",
+		Enabled:  true,
+	}
+	require.NoError(t, user.SetPassword("password123"))
+	require.NoError(t, db.DB.Create(user).Error)
+
+	// 5. Associate user with organization
+	user.OrganizationID = &org.ID
+	require.NoError(t, db.DB.Save(user).Error)
+
+	// Setup mock expectations - DeleteTemplateInstance should be called
+	mockK8sService.On("DeleteTemplateInstance", mock.Anything, vdc.Namespace, vapp.Name).Return(nil)
+
+	// Generate JWT token
+	token, err := jwtManager.Generate(user.ID, user.Username)
+	require.NoError(t, err)
+
+	// Setup gin in test mode
+	gin.SetMode(gin.TestMode)
+
+	// Create test request
+	router := gin.New()
+	router.DELETE("/cloudapi/1.0.0/vapps/:vapp_id", func(c *gin.Context) {
+		// Set mock claims
+		claims := &auth.Claims{
+			UserID: user.ID,
+		}
+		c.Set(auth.ClaimsContextKey, claims)
+		vappHandlers.DeleteVApp(c)
+	})
+
+	req, _ := http.NewRequest("DELETE", "/cloudapi/1.0.0/vapps/"+vapp.ID, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Verify the response
+	assert.Equal(t, http.StatusNoContent, w.Code)
+
+	// Verify that DeleteTemplateInstance was called with correct parameters
+	mockK8sService.AssertCalled(t, "DeleteTemplateInstance", mock.Anything, vdc.Namespace, vapp.Name)
+
+	// Verify vApp was deleted from database
+	var deletedVApp models.VApp
+	err = db.DB.Where("id = ?", vapp.ID).First(&deletedVApp).Error
+	assert.Error(t, err) // Should not be found
+}
+
+func TestVAppDeletion_HandlesKubernetesError(t *testing.T) {
+	// Setup test infrastructure
+	_, db, jwtManager := setupTestAPIServer(t)
+
+	// Create mock Kubernetes service
+	mockK8sService := &MockKubernetesService{}
+
+	// Setup repositories
+	orgRepo := repositories.NewOrganizationRepository(db.DB)
+	vdcRepo := repositories.NewVDCRepository(db.DB)
+	vappRepo := repositories.NewVAppRepository(db.DB)
+	vmRepo := repositories.NewVMRepository(db.DB)
+
+	// Create VApp handlers with mock K8s service
+	vappHandlers := handlers.NewVAppHandlers(vappRepo, vdcRepo, vmRepo, mockK8sService)
+
+	// Create test data
+	// 1. Create organization
+	org := &models.Organization{
+		Name:        "TestOrg",
+		DisplayName: "Test Organization",
+		IsEnabled:   true,
+	}
+	require.NoError(t, orgRepo.Create(org))
+
+	// 2. Create VDC
+	vdc := &models.VDC{
+		Name:            "TestVDC",
+		Description:     "Test VDC for vApp deletion",
+		OrganizationID:  org.ID,
+		AllocationModel: models.PayAsYouGo,
+		Namespace:       "test-namespace",
+		IsEnabled:       true,
+	}
+	require.NoError(t, vdcRepo.Create(vdc))
+
+	// 3. Create vApp
+	vapp := &models.VApp{
+		Name:        "test-vapp",
+		Description: "Test vApp for deletion",
+		VDCID:       vdc.ID,
+		Status:      models.VAppStatusDeployed,
+	}
+	require.NoError(t, vappRepo.CreateWithContext(context.Background(), vapp))
+
+	// 4. Create user
+	user := &models.User{
+		Username: "testuser",
+		Email:    "test@example.com",
+		FullName: "Test User",
+		Enabled:  true,
+	}
+	require.NoError(t, user.SetPassword("password123"))
+	require.NoError(t, db.DB.Create(user).Error)
+
+	// 5. Associate user with organization
+	user.OrganizationID = &org.ID
+	require.NoError(t, db.DB.Save(user).Error)
+
+	// Setup mock expectations - K8s service returns error but vApp deletion continues
+	mockK8sService.On("DeleteTemplateInstance", mock.Anything, vdc.Namespace, vapp.Name).Return(assert.AnError)
+
+	// Generate JWT token
+	token, err := jwtManager.Generate(user.ID, user.Username)
+	require.NoError(t, err)
+
+	// Setup gin in test mode
+	gin.SetMode(gin.TestMode)
+
+	// Create test request
+	router := gin.New()
+	router.DELETE("/cloudapi/1.0.0/vapps/:vapp_id", func(c *gin.Context) {
+		// Set mock claims
+		claims := &auth.Claims{
+			UserID: user.ID,
+		}
+		c.Set(auth.ClaimsContextKey, claims)
+		vappHandlers.DeleteVApp(c)
+	})
+
+	req, _ := http.NewRequest("DELETE", "/cloudapi/1.0.0/vapps/"+vapp.ID, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Verify the response - should still succeed despite K8s error
+	assert.Equal(t, http.StatusNoContent, w.Code)
+
+	// Verify that DeleteTemplateInstance was called
+	mockK8sService.AssertCalled(t, "DeleteTemplateInstance", mock.Anything, vdc.Namespace, vapp.Name)
+
+	// Verify vApp was still deleted from database despite K8s error
+	var deletedVApp models.VApp
+	err = db.DB.Where("id = ?", vapp.ID).First(&deletedVApp).Error
+	assert.Error(t, err) // Should not be found
+}


### PR DESCRIPTION
## Summary

Fixes the resource orphaning issue where vApp deletion only cleaned up database records but left associated TemplateInstance and VirtualMachine resources in the OpenShift cluster.

- ✅ Add KubernetesService dependency to VAppHandlers  
- ✅ Enhance DeleteVApp method to cleanup TemplateInstance before database deletion
- ✅ Use VDC namespace to locate and delete the corresponding TemplateInstance
- ✅ Implement graceful error handling that continues deletion even if K8s cleanup fails
- ✅ Follow existing patterns from VDC deletion for consistency

## Test plan

- [x] Unit tests verify TemplateInstance cleanup is called with correct parameters
- [x] Unit tests ensure vApp deletion succeeds even when K8s cleanup fails  
- [x] Tests use mock KubernetesService for isolated testing
- [x] All existing tests continue to pass
- [x] Code passes linting checks

## Technical Details

When a vApp is created via `CreateTemplateInstance`, it creates a TemplateInstance with the same name in the VDC's namespace. The enhanced deletion process now:

1. Retrieves VDC information to get the Kubernetes namespace
2. Calls `DeleteTemplateInstance` to cleanup the TemplateInstance resource
3. Continues with database cleanup regardless of K8s cleanup success/failure
4. Uses the same error handling pattern as VDC deletion

## Files Changed

- `pkg/api/handlers/vapps.go` - Enhanced DeleteVApp method and added KubernetesService dependency
- `pkg/api/server.go` - Updated VAppHandlers constructor call to pass k8sService  
- `test/unit/vapp_deletion_test.go` - Comprehensive unit tests for cleanup functionality

Resolves #55

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatic cleanup of related Kubernetes resources when deleting a vApp.
  - Enhanced vApp details in API responses, including references to contained VMs.

- Reliability
  - vApp deletion proceeds even if Kubernetes cleanup encounters errors, ensuring user operations are not blocked.

- Tests
  - Added unit tests covering vApp deletion with Kubernetes cleanup and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->